### PR TITLE
fix vision issues switching from imp to crew and when destroying bots

### DIFF
--- a/MCI/InstanceControl.cs
+++ b/MCI/InstanceControl.cs
@@ -30,13 +30,14 @@ namespace MCI
             PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(PlayerControl.LocalPlayer.transform.position);
             PlayerControl.LocalPlayer.moveable = false;
 
-            Object.Destroy(PlayerControl.LocalPlayer.lightSource);
+            var light = PlayerControl.LocalPlayer.lightSource;
 
             var newPlayer = Utils.PlayerById(playerId);
 
             HudManager.Instance.KillButton.buttonLabelText.gameObject.SetActive(false);
 
             PlayerControl.LocalPlayer = newPlayer;
+            PlayerControl.LocalPlayer.lightSource = light;
             PlayerControl.LocalPlayer.moveable = true;
 
             AmongUsClient.Instance.ClientId = PlayerControl.LocalPlayer.OwnerId;
@@ -45,15 +46,13 @@ namespace MCI
             HudManager.Instance.SetHudActive(true);
 
             //hacky "fix" for twix and det
-            
+
             HudManager.Instance.KillButton.transform.parent.GetComponentsInChildren<Transform>().ToList().ForEach((x) => { if (x.gameObject.name == "KillButton(Clone)") Object.Destroy(x.gameObject); });
             HudManager.Instance.KillButton.transform.GetComponentsInChildren<Transform>().ToList().ForEach((x) => { if (x.gameObject.name == "KillTimer_TMP(Clone)") Object.Destroy(x.gameObject); });
             HudManager.Instance.transform.GetComponentsInChildren<Transform>().ToList().ForEach((x) => { if (x.gameObject.name == "KillButton(Clone)") Object.Destroy(x.gameObject); });
 
-            PlayerControl.LocalPlayer.lightSource = Object.Instantiate(PlayerControl.LocalPlayer.LightPrefab);
-            PlayerControl.LocalPlayer.lightSource.transform.SetParent(PlayerControl.LocalPlayer.transform);
-            PlayerControl.LocalPlayer.lightSource.transform.localPosition = PlayerControl.LocalPlayer.Collider.offset;
-            PlayerControl.LocalPlayer.lightSource.Initialize(PlayerControl.LocalPlayer.Collider.offset * 0.5f);
+            light.transform.SetParent(PlayerControl.LocalPlayer.transform);
+            light.transform.localPosition = PlayerControl.LocalPlayer.Collider.offset;
             Camera.main.GetComponent<FollowerCamera>().SetTarget(PlayerControl.LocalPlayer);
             PlayerControl.LocalPlayer.MyPhysics.ResetMoveState(true);
             KillAnimation.SetMovement(PlayerControl.LocalPlayer, true);

--- a/MCI/MCI.csproj
+++ b/MCI/MCI.csproj
@@ -12,8 +12,8 @@
 
     <PropertyGroup>
         <GamePlatform Condition="'$(GamePlatform)' == ''">Steam</GamePlatform>
-        <GameVersion Condition="'$(GamePlatform)' == 'Steam'">2022.12.14</GameVersion>
-        <GameVersion Condition="'$(GamePlatform)' == 'Itch'">2022.12.14</GameVersion>
+        <GameVersion Condition="'$(GamePlatform)' == 'Steam'">2023.2.28</GameVersion>
+        <GameVersion Condition="'$(GamePlatform)' == 'Itch'">2023.2.28</GameVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/MCI/Utils.cs
+++ b/MCI/Utils.cs
@@ -51,17 +51,10 @@ namespace MCI
             return null;
         }
 
-
-
-
-
-
-
         public static void RemovePlayer(byte id)
         {
             int clientId = InstanceControl.clients.FirstOrDefault(x => x.Value.Character.PlayerId == id).Key;
-            ClientData outputData;
-            InstanceControl.clients.Remove(clientId, out outputData);
+            InstanceControl.clients.Remove(clientId, out ClientData outputData);
             InstanceControl.PlayerIdClientId.Remove(id);
             AmongUsClient.Instance.RemovePlayer(clientId, DisconnectReasons.ExitGame);
             AmongUsClient.Instance.allClients.Remove(outputData);
@@ -70,7 +63,7 @@ namespace MCI
         public static void RemoveAllPlayers()
         {
             foreach (byte playerId in InstanceControl.PlayerIdClientId.Keys) RemovePlayer(playerId);
+            InstanceControl.SwitchTo(AmongUsClient.Instance.allClients[0].Character.PlayerId);
         }
     }
 }
-


### PR DESCRIPTION
this pr fixes the following:
when switching from imp to crew the vision becomes a circle and outside of it it is grey as if there is a collider
when destroying robots while being on one the light source stays and you arent put back to your own player

csproj has been bumped to latest version