### PR TITLE
Adding a Debugger to Mci

### DIFF
--- a/MCI/MCI.csproj
+++ b/MCI/MCI.csproj
@@ -19,6 +19,7 @@
     <ItemGroup>
         <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.670" />
         <PackageReference Include="AmongUs.GameLibs.$(GamePlatform)" Version="$(GameVersion)" PrivateAssets="all" />
+        <PackageReference Include="Reactor" Version="2.2.0" />
 
         <PackageReference Include="BepInEx.AutoPlugin" Version="1.1.0" PrivateAssets="all" />
         <PackageReference Include="BepInEx.IL2CPP.MSBuild" Version="2.0.1" PrivateAssets="all" />

--- a/MCI/MCI.csproj
+++ b/MCI/MCI.csproj
@@ -12,8 +12,8 @@
 
     <PropertyGroup>
         <GamePlatform Condition="'$(GamePlatform)' == ''">Steam</GamePlatform>
-        <GameVersion Condition="'$(GamePlatform)' == 'Steam'">2023.6.13</GameVersion>
-        <GameVersion Condition="'$(GamePlatform)' == 'Itch'">2023.6.13</GameVersion>
+        <GameVersion Condition="'$(GamePlatform)' == 'Steam'">2024.3.5</GameVersion>
+        <GameVersion Condition="'$(GamePlatform)' == 'Itch'">2024.3.5</GameVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/MCI/MCIPlugin.cs
+++ b/MCI/MCIPlugin.cs
@@ -48,4 +48,13 @@ namespace MCI
 
         internal static bool Persistence = true;
     }
+    
+    [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.Update))]
+    public static class CountdownPatch
+    {
+        public static void Prefix(GameStartManager __instance)
+        {
+            __instance.countDownTimer = 0;
+        }
+    }
 }

--- a/MCI/MCIPlugin.cs
+++ b/MCI/MCIPlugin.cs
@@ -1,6 +1,8 @@
-﻿using BepInEx;
+using BepInEx;
 using BepInEx.Unity.IL2CPP;
 using HarmonyLib;
+using Il2CppInterop.Runtime.Injection;
+using MCI.Patches;
 using System;
 using UnityEngine.SceneManagement;
 
@@ -30,6 +32,10 @@ namespace MCI
             UpdateChecker.CheckForUpdate();
 
             SubmergedCompatibility.Initialize();
+            
+            this.AddComponent<DebuggerBehaviour>();
+            
+            ClassInjector.RegisterTypeInIl2Cpp<DebuggerBehaviour>();
 
             SceneManager.add_sceneLoaded((Action<Scene, LoadSceneMode>)((scene, _) =>
             {
@@ -41,14 +47,5 @@ namespace MCI
         }
 
         internal static bool Persistence = true;
-    }
-
-    [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.Update))]
-    public static class CountdownPatch
-    {
-        public static void Prefix(GameStartManager __instance)
-        {
-            __instance.countDownTimer = 0;
-        }
     }
 }

--- a/MCI/Patches/Debugger.cs
+++ b/MCI/Patches/Debugger.cs
@@ -17,7 +17,7 @@ namespace MCI.Patches
             TestWindow = new(new(20, 20, 0, 0), "MCI Debugger", () =>
             {
                 GUILayout.Label("Name: " + DataManager.Player.Customization.Name);
-                GUILayout.Label("Made by le killer with help from whichTwix"); //based off from Reactor.Debugger but remade by AlchlcDvl and updated to vanilla
+                GUILayout.Label("Made by le killer, AlchlcDvl with help from whichTwix"); //based off from Reactor.Debugger but remade by AlchlcDvl and updated to vanilla
                 
                 if (PlayerControl.LocalPlayer)
                 {

--- a/MCI/Patches/Debugger.cs
+++ b/MCI/Patches/Debugger.cs
@@ -1,0 +1,177 @@
+using AmongUs.Data;
+using Reactor.Utilities.ImGui;
+using Il2CppInterop.Runtime.Attributes;
+using UnityEngine;
+using InnerNet;
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
+
+namespace MCI.Patches
+{
+    public class DebuggerBehaviour : MonoBehaviour
+    {
+        [HideFromIl2Cpp]
+        public DragWindow TestWindow { get; }
+        private static byte ControllingFigure;
+        public DebuggerBehaviour(System.IntPtr ptr) : base(ptr)
+        {
+            TestWindow = new(new(20, 20, 0, 0), "MCI Debugger", () =>
+            {
+                GUILayout.Label("Name: " + DataManager.Player.Customization.Name);
+                GUILayout.Label("Made by le killer with help from whichTwix"); //based off from Reactor.Debugger but remade by AlchlcDvl and updated to vanilla
+                
+                if (PlayerControl.LocalPlayer)
+                {
+                    var position = PlayerControl.LocalPlayer.gameObject.transform.position;
+                    GUILayout.Label($"Player Position\nx: {position.x:00.00} y: {position.y:00.00} z: {position.z:00.00}");
+
+                    var mouse = Input.mousePosition;
+                    GUILayout.Label($"Mouse Position\nx: {mouse.x:00.00} y: {mouse.y:00.00} z: {mouse.z:00.00}");
+                }
+
+                if (PlayerControl.LocalPlayer && !PlayerControl.LocalPlayer.Data.IsDead && MCIPlugin.Enabled)
+                    {
+                    PlayerControl.LocalPlayer.Collider.enabled = GUILayout.Toggle(PlayerControl.LocalPlayer.Collider.enabled, "Enable Player Collider");
+                    }
+
+                if (!MCIPlugin.Enabled)
+                {
+                    GUILayout.Label("Debugger features only work on localhosted lobbies");
+                }
+
+                if (!MCIPlugin.Enabled) return;
+                if (PlayerControl.LocalPlayer && AmongUsClient.Instance?.GameState == InnerNetClient.GameStates.Joined && AmongUsClient.Instance.GameState != InnerNet.InnerNetClient.GameStates.Ended)
+                    {
+                
+                    if (GUILayout.Button("Spawn Bot"))
+                    {
+                        if (PlayerControl.AllPlayerControls.Count < 15)
+                        {
+                            Utils.CleanUpLoad();
+                            Utils.CreatePlayerInstance(MCIPlugin.RobotName);
+                        }
+                    }
+
+                    if (GUILayout.Button("Remove Last Bot"))
+                    {
+                        Utils.RemovePlayer((byte)InstanceControl.clients.Count);
+                    }
+
+                    if (GUILayout.Button("Remove All Bots"))
+                    {
+                        Utils.RemoveAllPlayers();
+                    }
+
+                    }
+                else if (AmongUsClient.Instance?.GameState == InnerNetClient.GameStates.Started || GameManager.Instance?.GameHasStarted == true ||
+                        AmongUsClient.Instance?.IsGameStarted == true && AmongUsClient.Instance.GameState != InnerNet.InnerNetClient.GameStates.Ended)
+                {
+
+                    if (GUILayout.Button("Next Player"))
+                    {
+                        ControllingFigure++;
+                        ControllingFigure = (byte) Mathf.Clamp(ControllingFigure, 0, PlayerControl.AllPlayerControls.Count - 1);
+                        InstanceControl.SwitchTo(ControllingFigure);
+                    }
+                    else if (GUILayout.Button("Previous Player"))
+                    {
+                        ControllingFigure--;
+                        ControllingFigure = (byte) Mathf.Clamp(ControllingFigure, 0, PlayerControl.AllPlayerControls.Count - 1);
+                        InstanceControl.SwitchTo(ControllingFigure);
+                    }
+
+                    if (GUILayout.Button("End Game"))
+                    {
+                        GameManager.Instance.RpcEndGame(GameOverReason.ImpostorBySabotage, false);
+                    }
+
+                    if (GUILayout.Button("Turn Impostor"))
+                    {
+                        PlayerControl.LocalPlayer.Data.Role.TeamType = RoleTeamTypes.Impostor;
+                    if (PlayerControl.LocalPlayer.Data.IsDead != PlayerControl.LocalPlayer)
+                    {
+                        RoleManager.Instance.SetRole(PlayerControl.LocalPlayer, AmongUs.GameOptions.RoleTypes.Impostor);
+                        DestroyableSingleton<HudManager>.Instance.KillButton.gameObject.SetActive(true);
+                        PlayerControl.LocalPlayer.SetKillTimer(GameOptionsManager.Instance.currentNormalGameOptions.KillCooldown);
+                    }
+                    else
+                    {
+                        RoleManager.Instance.SetRole(PlayerControl.LocalPlayer, AmongUs.GameOptions.RoleTypes.ImpostorGhost);
+                    }
+                    }
+
+                    if (GUILayout.Button("Turn Crewmate"))
+                    {
+                        PlayerControl.LocalPlayer.Data.Role.TeamType = RoleTeamTypes.Crewmate;
+                    if (PlayerControl.LocalPlayer.Data.IsDead != PlayerControl.LocalPlayer)
+                    {
+                        RoleManager.Instance.SetRole(PlayerControl.LocalPlayer, AmongUs.GameOptions.RoleTypes.Crewmate);
+                    }
+                    else
+                    {
+                        RoleManager.Instance.SetRole(PlayerControl.LocalPlayer, AmongUs.GameOptions.RoleTypes.CrewmateGhost);
+                    }
+                    }
+
+                    if (GUILayout.Button("Complete Tasks"))
+                        foreach (var task in PlayerControl.LocalPlayer.myTasks)
+                        {
+                            PlayerControl.LocalPlayer.RpcCompleteTask(task.Id);
+                        }
+
+                    if (GUILayout.Button("Complete Everyone's Tasks"))
+                        foreach (var player in PlayerControl.AllPlayerControls)
+                        {
+                            foreach (var task in player.myTasks)
+                            {
+                                player.RpcCompleteTask(task.Id);
+                            }
+                        }
+
+                    if (GUILayout.Button("Redo Intro Sequence"))
+                    {
+                        HudManager.Instance.StartCoroutine(HudManager.Instance.CoFadeFullScreen(Color.clear, Color.black));
+                        HudManager.Instance.StartCoroutine(HudManager.Instance.CoShowIntro());
+                    }
+
+                    if (GUILayout.Button("Start Meeting") && !MeetingHud.Instance)
+                    {
+                        PlayerControl.LocalPlayer.RemainingEmergencies++;
+                        PlayerControl.LocalPlayer.CmdReportDeadBody(null);
+                    }
+
+                    if (GUILayout.Button("End Meeting") && MeetingHud.Instance)
+                        MeetingHud.Instance.RpcClose();
+
+                    if (GUILayout.Button("Kill Self"))
+                        PlayerControl.LocalPlayer.RpcMurderPlayer(PlayerControl.LocalPlayer, true);
+
+                    if (GUILayout.Button("Kill All"))
+                        foreach (var player in PlayerControl.AllPlayerControls)
+                        {
+                          player.RpcMurderPlayer(player, true);
+                        }
+
+                    if (GUILayout.Button("Revive Self"))
+                        PlayerControl.LocalPlayer.Revive();
+
+                    if (GUILayout.Button("Revive All"))
+                        foreach (var player in PlayerControl.AllPlayerControls)
+                        {
+                            player.Revive();
+                        }
+                }
+            });
+        }
+
+        public void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.F1))
+                TestWindow.Enabled = !TestWindow.Enabled;
+        }
+
+        public void OnGUI()
+        {
+        TestWindow.OnGUI();
+        }
+    }
+}


### PR DESCRIPTION
I created a debugger (based off reactor.debugger) just for mci. It has some useful functions as you can see in the screenshots. Here is a list:
In lobby / in Game:
- See mouse position
- See player position
- Display the player's name
- Enable / Disable player collider
In lobby only:
- Spawn a bot (same thing as F5)
- Remove the latest bot which joined
- Remove all bots (same as F11)
Screenshot:
<img width="173" alt="lobby debugger" src="https://github.com/MyDragonBreath/AmongUs.MultiClientInstancing/assets/141348096/23dc1cc8-3bd0-49c5-b844-7d764a89b8ca">


In Game:
- Select the next bot
- Select the previous bot
- End the game
- Turn impostor
- Turn crewmate
- Complete self tasks
- Complete everyone's tasks
- Show the role intro sentence
- Start a meeting
- End a meeting
- Kill self
- Kill all
- Revive self
- Revive all
Screenshot:
<img width="173" alt="game debugger" src="https://github.com/MyDragonBreath/AmongUs.MultiClientInstancing/assets/141348096/0eab25da-464a-40ec-8c74-f1fa39fe7efe">


Of course, those features (except mouse and player position and player name) are only available for localhosted lobbies, else it would show a message telling that features won't work as you can see there:
<img width="172" alt="non localhosted debugger" src="https://github.com/MyDragonBreath/AmongUs.MultiClientInstancing/assets/141348096/68d22bb4-68b4-4249-82bd-a5d5835ef9e4">


This Debugger was made by me with help from whichTwix but is first an idea of AlchlcDvl so thanks for both them for helping me. (PS: I think you can delete the old pull request lol)